### PR TITLE
Strip utm_cid

### DIFF
--- a/background.js
+++ b/background.js
@@ -2,7 +2,7 @@ chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
     var queryStringIndex = tab.url.indexOf('?');
     if (tab.url.indexOf('utm_') > queryStringIndex) {
         var stripped = tab.url.replace(
-            /([\?\&]utm_(source|medium|term|campaign|content)=[^&#]+)/ig,
+            /([\?\&]utm_(source|medium|term|campaign|content|cid)=[^&#]+)/ig,
             '');
         if (stripped.charAt(queryStringIndex) === '&') {
             stripped = stripped.substr(0, queryStringIndex) + '?' +


### PR DESCRIPTION
After installing the Chrome Web Store version, I was still seeing utm based query params on my Chrome tabs. For example:

```
http://mashable.com/2013/11/17/domain-name-research-tools/?utm_cid=Mash-Prod-RSS-Feedburner-All-Partial
```

This pull request includes a quick fix to strip utm_cid params as well.
