### PR TITLE
Include utm_reader in stripped parameters

### DIFF
--- a/background.js
+++ b/background.js
@@ -2,7 +2,7 @@ chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
     var queryStringIndex = tab.url.indexOf('?');
     if (tab.url.indexOf('utm_') > queryStringIndex) {
         var stripped = tab.url.replace(
-            /([\?\&]utm_(source|medium|term|campaign|content|cid)=[^&#]+)/ig,
+            /([\?\&]utm_(source|medium|term|campaign|content|cid|reader)=[^&#]+)/ig,
             '');
         if (stripped.charAt(queryStringIndex) === '&') {
             stripped = stripped.substr(0, queryStringIndex) + '?' +


### PR DESCRIPTION
This is commonly used by Feedly and some other RSS readers.
