### PR TITLE
Block Facebook click ID parameter

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,9 +1,9 @@
-var utm_re = new RegExp('([\?\&](fbclid|utm_(source|medium|term|campaign|content|cid|reader|name))=[^&#]+)', 'ig');
+var utm_re = new RegExp('([\?\&]((g|fb)clid|utm_(source|medium|term|campaign|content|cid|reader|name))=[^&#]+)', 'ig');
 
 chrome.webRequest.onBeforeRequest.addListener(function(details) {
     var url = details.url;
     var queryStringIndex = url.indexOf('?');
-    if (url.indexOf('utm_') > queryStringIndex || url.indexOf('fbclid') > queryStringIndex) {
+    if (url.indexOf('utm_') > queryStringIndex || url.indexOf('clid') > queryStringIndex) {
         var stripped = url.replace(utm_re, '');
         if (stripped.charAt(queryStringIndex) === '&') {
             stripped = stripped.substr(0, queryStringIndex) + '?' +

--- a/background.js
+++ b/background.js
@@ -1,9 +1,9 @@
-var utm_re = new RegExp('([\?\&]utm_(source|medium|term|campaign|content|cid|reader|name)=[^&#]+)', 'ig');
+var utm_re = new RegExp('([\?\&](fbclid|utm_(source|medium|term|campaign|content|cid|reader|name))=[^&#]+)', 'ig');
 
 chrome.webRequest.onBeforeRequest.addListener(function(details) {
     var url = details.url;
     var queryStringIndex = url.indexOf('?');
-    if (url.indexOf('utm_') > queryStringIndex) {
+    if (url.indexOf('utm_') > queryStringIndex || url.indexOf('fbclid') > queryStringIndex) {
         var stripped = url.replace(utm_re, '');
         if (stripped.charAt(queryStringIndex) === '&') {
             stripped = stripped.substr(0, queryStringIndex) + '?' +

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 	"version": "2.2",
 	"manifest_version": 2,
 	"author": "Jon Parise",
-	"description": "Removes Google Analytics (UTM), Facebook Click tracking tokens from URL query strings.",
+	"description": "Removes Google Analytics (UTM), Google and Facebook Click tracking tokens from URL query strings.",
 	"homepage_url": "https://github.com/jparise/chrome-utm-stripper",
 	"icons" :{
 		"48" : "icon-48.png",

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
 	"name": "Tracking Token Stripper",
-	"version": "2.1",
+	"version": "2.2",
 	"manifest_version": 2,
 	"author": "Jon Parise",
-	"description": "Removes Google Analytics (UTM) tracking tokens from URL query strings.",
+	"description": "Removes Google Analytics (UTM), Facebook Click tracking tokens from URL query strings.",
 	"homepage_url": "https://github.com/jparise/chrome-utm-stripper",
 	"icons" :{
 		"48" : "icon-48.png",


### PR DESCRIPTION
Facebook recently added a new "click id" query string parameter (see https://stackoverflow.com/questions/52847475/what-is-fbclid-the-new-facebook-parameter).

This pull request gets rid of it :)
Tested using Chrome 69. 

Thanks!