### PR TITLE
Strip HubSpot parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ The following query string parameters are stripped:
 
  - fbclid
  - gclid
+ - _hsenc
+ - _hsmi
  - ICID
  - mc_cid
  - mc_eid

--- a/background.js
+++ b/background.js
@@ -3,7 +3,7 @@
  * parameter. We'll search the query string portion of the URL for this
  * pattern to determine if there's any stripping work to do.
  */
-var searchPattern = new RegExp('utm_|clid|icid|mc_|mkt_tok', 'i');
+var searchPattern = new RegExp('utm_|clid|_hs|icid|mc_|mkt_tok', 'i');
 
 /*
  * Pattern matching the query string parameters (key=value) that will be
@@ -11,7 +11,7 @@ var searchPattern = new RegExp('utm_|clid|icid|mc_|mkt_tok', 'i');
  */
 var replacePattern = new RegExp(
     '([?&]' +
-    '(icid|mkt_tok|(g|fb)clid|mc_[ce]id|utm_(source|medium|term|campaign|content|cid|reader|referrer|name|social|social-type))' +
+    '(icid|mkt_tok|(g|fb)clid|_hs(enc|mi)|mc_[ce]id|utm_(source|medium|term|campaign|content|cid|reader|referrer|name|social|social-type))' +
     '=[^&#]*)',
     'ig');
 


### PR DESCRIPTION
[See this article](https://knowledge.hubspot.com/reports/why-do-i-see-so-many-urls-for-the-same-page-in-google-analytics-for-visits-from-hubspot-emails) for documentation on these parameters.