### PR TITLE
Strip wickedid from URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The following query string parameters are stripped:
  - utm_name
  - utm_social
  - utm_social-type
+ - wickedid
  - yclid
 
 This extension requires these [permissions][]:

--- a/background.js
+++ b/background.js
@@ -3,7 +3,7 @@
  * parameter. We'll search the query string portion of the URL for this
  * pattern to determine if there's any stripping work to do.
  */
-var searchPattern = new RegExp('utm_|clid|_hs|icid|igshid|mc_|mkt_tok|yclid|_openstat', 'i');
+var searchPattern = new RegExp('utm_|clid|_hs|icid|igshid|mc_|mkt_tok|yclid|_openstat|wicked', 'i');
 
 /*
  * Pattern matching the query string parameters (key=value) that will be
@@ -11,7 +11,7 @@ var searchPattern = new RegExp('utm_|clid|_hs|icid|igshid|mc_|mkt_tok|yclid|_ope
  */
 var replacePattern = new RegExp(
     '([?&]' +
-    '(icid|mkt_tok|(g|fb)clid|igshid|_hs(enc|mi)|mc_[ce]id|utm_(source|medium|term|campaign|content|cid|reader|referrer|name|social|social-type)|yclid|_openstat)' +
+    '(icid|mkt_tok|(g|fb)clid|igshid|_hs(enc|mi)|mc_[ce]id|utm_(source|medium|term|campaign|content|cid|reader|referrer|name|social|social-type)|yclid|_openstat|wickedid)' +
     '=[^&#]*)',
     'ig');
 


### PR DESCRIPTION
This appears to be a parameter used by Wicked Reports
(https://wickedreports.com) for tracking Facebook ads.

Fixed #38 