### PR TITLE
Added # to beginning of regexp

### DIFF
--- a/background.js
+++ b/background.js
@@ -10,7 +10,7 @@ const searchPattern = new RegExp('utm_|stm_|clid|_hs|icid|igshid|mc_|mkt_tok|ycl
  * stripped from the final URL.
  */
 const replacePattern = new RegExp(
-    '([?&]' +
+    '([?&#]' +
     '(icid|mkt_tok|(g|fb)clid|igshid|_hs(enc|mi)|mc_[ce]id|(utm|stm)_(source|medium|term|campaign|content|cid|reader|referrer|name|social|social-type)|rb_clickid|yclid|_openstat|wickedid|otc|oly_(anon|enc)_id|soc_(src|trk))' +
     '=[^&#]*)',
     'ig');


### PR DESCRIPTION
feedly.com opens some pages with # at the beginning of query string, e.g.:
https://www.idnes.cz/zpravy/mediahub/eu-spolecna-redakce-tiskove-agentury.A211130_083833_mediahub_jpl#utm_source=rss&utm_medium=feed&utm_campaign=zpravodaj&utm_content=main

so stripper doesn't match.