### PR TITLE
Strip 'cvid' and 'oicd' parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ The following query string parameters are stripped:
   - `mc_eid`
 - [Marketo](https://www.marketo.com/)
   - `mkt_tok`
+- Microsoft (MSN/Bing)
+  - `cvid`
+  - `oicd`
 - [Olytics](https://main.omeda.com/knowledge-base/olytics-product-outline/)
   - `oly_anon_id`
   - `oly_enc_id`

--- a/background.js
+++ b/background.js
@@ -3,7 +3,7 @@
  * parameter. We'll search the query string portion of the URL for this
  * pattern to determine if there's any stripping work to do.
  */
-const searchPattern = new RegExp('utm_|stm_|clid|_hs|icid|igshid|mc_|mkt_tok|yclid|_openstat|wicked|otc|oly_|rb_clickid|soc_', 'i');
+const searchPattern = new RegExp('utm_|stm_|clid|_hs|icid|igshid|mc_|mkt_tok|yclid|_openstat|wicked|otc|oly_|rb_clickid|soc_|cvid|oicd', 'i');
 
 /*
  * Pattern matching the query string parameters (key=value) that will be
@@ -11,7 +11,7 @@ const searchPattern = new RegExp('utm_|stm_|clid|_hs|icid|igshid|mc_|mkt_tok|ycl
  */
 const replacePattern = new RegExp(
     '([?&]' +
-    '(icid|mkt_tok|(g|fb)clid|igshid|_hs(enc|mi)|mc_[ce]id|(utm|stm)_(source|medium|term|campaign|content|cid|reader|referrer|name|social|social-type)|rb_clickid|yclid|_openstat|wickedid|otc|oly_(anon|enc)_id|soc_(src|trk))' +
+    '(icid|mkt_tok|(g|fb)clid|igshid|_hs(enc|mi)|mc_[ce]id|(utm|stm)_(source|medium|term|campaign|content|cid|reader|referrer|name|social|social-type)|rb_clickid|yclid|_openstat|wickedid|otc|oly_(anon|enc)_id|soc_(src|trk)|cvid|oicd)' +
     '=[^&#]*)',
     'ig');
 


### PR DESCRIPTION
These are added by Microsoft (MSN/Bing) web properties.

Resolves #57
